### PR TITLE
Fix on image loading problems when using WebImageView in ListView

### DIFF
--- a/src/main/java/com/github/droidfu/adapters/WebGalleryAdapter.java
+++ b/src/main/java/com/github/droidfu/adapters/WebGalleryAdapter.java
@@ -104,23 +104,35 @@ public class WebGalleryAdapter extends BaseAdapter {
         return progressDrawable;
     }
 
-    // TODO: leverage convert view for better performance
     public View getView(int position, View convertView, ViewGroup parent) {
 
         String imageUrl = (String) getItem(position);
 
-        FrameLayout container = new FrameLayout(context);
-        container.setLayoutParams(new Gallery.LayoutParams(LayoutParams.FILL_PARENT,
-                LayoutParams.FILL_PARENT));
+        FrameLayout container;
+        WebImageView item;
 
-        WebImageView item = new WebImageView(context, imageUrl, progressDrawable, false);
-        FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
-                LayoutParams.WRAP_CONTENT);
-        lp.gravity = Gravity.CENTER;
-        item.setLayoutParams(lp);
+        if (convertView == null) {
+            container = new FrameLayout(context);
+            container.setLayoutParams(new Gallery.LayoutParams(LayoutParams.FILL_PARENT,
+                    LayoutParams.FILL_PARENT));
 
-        container.addView(item);
+            item = new WebImageView(context, null, false);
+            item.setProgressDrawable(progressDrawable);
+            FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(LayoutParams.WRAP_CONTENT,
+                    LayoutParams.WRAP_CONTENT);
+            lp.gravity = Gravity.CENTER;
+            item.setLayoutParams(lp);
 
+            container.addView(item, 0);
+        } else {
+            container = (FrameLayout) convertView;
+            item = (WebImageView) container.getChildAt(0);
+        }
+
+        // calling reset is important to prevent old images from displaying in a recycled view.
+        item.reset();
+
+        item.setImageUrl(imageUrl);
         item.loadImage();
 
         onGetView(position, convertView, parent);
@@ -129,5 +141,6 @@ public class WebGalleryAdapter extends BaseAdapter {
     }
 
     protected void onGetView(int position, View convertView, ViewGroup parent) {
+        // for extension
     }
 }

--- a/src/main/java/com/github/droidfu/imageloader/ImageLoader.java
+++ b/src/main/java/com/github/droidfu/imageloader/ImageLoader.java
@@ -51,6 +51,7 @@ public class ImageLoader implements Runnable {
     public static final int HANDLER_MESSAGE_ID = 0;
 
     public static final String BITMAP_EXTRA = "droidfu:extra_bitmap";
+    public static final String IMAGE_URL_EXTRA = "droidfu:extra_image_url";
 
     private static final int NO_POSITION = -1;
 
@@ -189,7 +190,7 @@ public class ImageLoader implements Runnable {
                 // fetch the image in the background
                 executor.execute(loader);
             } else {
-                loader.notifyImageLoaded(image);
+                loader.notifyImageLoaded(imageUrl, image);
             }
         }
     }
@@ -238,14 +239,15 @@ public class ImageLoader implements Runnable {
         }
 
         if (bitmap != null) {
-            notifyImageLoaded(bitmap);
+            notifyImageLoaded(imageUrl, bitmap);
         }
     }
 
-    public void notifyImageLoaded(Bitmap bitmap) {
+    public void notifyImageLoaded(String url, Bitmap bitmap) {
         Message message = new Message();
         message.what = HANDLER_MESSAGE_ID;
         Bundle data = new Bundle();
+        data.putString(IMAGE_URL_EXTRA, url);
         data.putParcelable(BITMAP_EXTRA, bitmap);
         message.setData(data);
 

--- a/src/main/java/com/github/droidfu/imageloader/ImageLoader.java
+++ b/src/main/java/com/github/droidfu/imageloader/ImageLoader.java
@@ -132,7 +132,17 @@ public class ImageLoader implements Runnable {
      * Triggers the image loader for the given image and view. The image loading
      * will be performed concurrently to the UI main thread, using a fixed size
      * thread pool. The loaded image will be posted back to the given ImageView
-     * upon completion. This method is intended to be used in a ListAdapter.
+     * upon completion.
+     *
+     * This method is intended to be used in a ListAdapter (for a ListView) after setting
+     * the list item's position to the ImageView using <code>setTag(position)</code>.
+     * Since ListViews re-use views for performance optimization, it is not guaranteed that when
+     * the image has finished downloading, the target ImageView will still be used to render the
+     * requested image.
+     * ImageLoaderHandler checks that the index originally intended for a given image is the same
+     * as the last index set using setTag(), and can prevent a flicker effect after many images are
+     * loaded for the same ImageView.
+     *
      * 
      * @param imageUrl the URL of the image to download
      * @param imageView the ImageView which should be updated with the new image
@@ -145,15 +155,7 @@ public class ImageLoader implements Runnable {
         } else {
             loader = new ImageLoader(imageUrl, imageView, position);
         }
-        synchronized (imageCache) {
-            Bitmap image = imageCache.get(imageUrl);
-            if (image == null) {
-                // fetch the image in the background
-                executor.execute(loader);
-            } else {
-                imageView.setImageBitmap(image);
-            }
-        }
+        doLoadImage(loader);
     }
     
     /**
@@ -171,6 +173,16 @@ public class ImageLoader implements Runnable {
      */
     public static void start(String imageUrl, ImageLoaderHandler handler) {
         ImageLoader loader = new ImageLoader(imageUrl, handler);
+        doLoadImage(loader);
+    }
+
+    /**
+     * Loads the target image either from the cache or by downloading it.
+     * @param loader loader instance that will be used if a download is required.
+     */
+    private static void doLoadImage(ImageLoader loader) {
+        String imageUrl = loader.imageUrl;
+
         synchronized (imageCache) {
             Bitmap image = imageCache.get(imageUrl);
             if (image == null) {

--- a/src/main/java/com/github/droidfu/imageloader/ImageLoaderHandler.java
+++ b/src/main/java/com/github/droidfu/imageloader/ImageLoaderHandler.java
@@ -38,19 +38,23 @@ public class ImageLoaderHandler extends Handler {
     @Override
     public void handleMessage(Message msg) {
         if (msg.what == ImageLoader.HANDLER_MESSAGE_ID) {
-            // If this handler is used for loading images in a ListAdapter, 
-            // the thread will set the image only if it's the right position, 
-            // otherwise it won't do anything.
-            if (position != null) {
-                int forPosition = (Integer) imageView.getTag();
-                if (forPosition != this.position) {
-                    return;
-                }
-            }
-            Bundle data = msg.getData();
-            Bitmap bitmap = data.getParcelable(ImageLoader.BITMAP_EXTRA);
-            imageView.setImageBitmap(bitmap);
+            handleImageLoadedMessage(msg);
         }
+    }
+
+    protected void handleImageLoadedMessage(Message msg) {
+        // If this handler is used for loading images in a ListAdapter,
+        // the thread will set the image only if it's the right position,
+        // otherwise it won't do anything.
+        if (position != null) {
+            int forPosition = (Integer) imageView.getTag();
+            if (forPosition != this.position) {
+                return;
+            }
+        }
+        Bundle data = msg.getData();
+        Bitmap bitmap = data.getParcelable(ImageLoader.BITMAP_EXTRA);
+        imageView.setImageBitmap(bitmap);
     }
 
     public ImageView getImageView() {

--- a/src/main/java/com/github/droidfu/widgets/WebImageView.java
+++ b/src/main/java/com/github/droidfu/widgets/WebImageView.java
@@ -18,6 +18,7 @@ package com.github.droidfu.widgets;
 import android.content.Context;
 import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Bundle;
 import android.os.Message;
 import android.util.AttributeSet;
 import android.view.Gravity;
@@ -201,10 +202,22 @@ public class WebImageView extends ViewSwitcher {
         }
 
         @Override
-        public void handleMessage(Message msg) {
-            super.handleMessage(msg);
-            isLoaded = true;
+        protected void handleImageLoadedMessage(Message msg) {
 
+            Bundle data = msg.getData();
+            String loadedUrl = data.getString(ImageLoader.IMAGE_URL_EXTRA);
+
+            // if an image url is specified, make sure this is the one we are expecting now
+            if (loadedUrl != null && !loadedUrl.equals(imageUrl)) {
+                // this happens when multiple download requests are made concurrently.
+                // we always want to show the last requested image, so we discard when mismatched
+                return;
+            }
+
+
+            super.handleImageLoadedMessage(msg);
+
+            isLoaded = true;
             setDisplayedChild(1);
         }
     }


### PR DESCRIPTION
By passing the image URL in the message that is sent by the ImageLoader after an image is finished downloaded, we can compare the loaded image's URL with the last URL that was set on the WebImageView instance (using setImageUrl). Doing so allows us to make sure that only the right image is shown.

This fix comes after experiencing flickering problems in my ListViews with many items. Scrolling down and up sometimes caused flickering of images because of the way ListViews are designed (views get re-used in Adapter.getView).

This change does not disrupt existing functionality!
Cheers!
