### PR TITLE
HTTP GZip support for DroidFu BetterHttp

### DIFF
--- a/src/main/java/com/github/droidfu/activities/BetterPreferenceActivity.java
+++ b/src/main/java/com/github/droidfu/activities/BetterPreferenceActivity.java
@@ -1,0 +1,163 @@
+/* Copyright (c) 2009 Matthias Käppler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.droidfu.activities;
+
+import java.util.List;
+
+import android.app.AlertDialog;
+import android.app.Application;
+import android.app.Dialog;
+import android.content.Intent;
+import android.content.DialogInterface.OnClickListener;
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.view.KeyEvent;
+
+import com.github.droidfu.DroidFuApplication;
+import com.github.droidfu.dialogs.DialogClickListener;
+
+public class BetterPreferenceActivity extends PreferenceActivity implements BetterActivity {
+
+    private boolean wasCreated, wasInterrupted;
+
+    private int progressDialogTitleId;
+
+    private int progressDialogMsgId;
+
+    private Intent currentIntent;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        this.wasCreated = true;
+        this.currentIntent = getIntent();
+
+        Application application = getApplication();
+        if (application instanceof DroidFuApplication) {
+            ((DroidFuApplication) application)
+                    .setActiveContext(getClass().getCanonicalName(), this);
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // ((DroidFuApplication)
+        // getApplication()).resetActiveContext(getClass().getCanonicalName());
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        wasInterrupted = true;
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        wasCreated = wasInterrupted = false;
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        this.currentIntent = intent;
+    }
+
+    @Override
+    protected Dialog onCreateDialog(int id) {
+        return BetterActivityHelper.createProgressDialog(this, progressDialogTitleId,
+            progressDialogMsgId);
+    }
+
+    public void setProgressDialogTitleId(int progressDialogTitleId) {
+        this.progressDialogTitleId = progressDialogTitleId;
+    }
+
+    public void setProgressDialogMsgId(int progressDialogMsgId) {
+        this.progressDialogMsgId = progressDialogMsgId;
+    }
+
+    public int getWindowFeatures() {
+        return BetterActivityHelper.getWindowFeatures(this);
+    }
+
+    public boolean isRestoring() {
+        return wasInterrupted;
+    }
+
+    public boolean isResuming() {
+        return !wasCreated;
+    }
+
+    public boolean isLaunching() {
+        return !wasInterrupted && wasCreated;
+    }
+
+    public boolean isApplicationBroughtToBackground() {
+        return BetterActivityHelper.isApplicationBroughtToBackground(this);
+    }
+
+    public Intent getCurrentIntent() {
+        return currentIntent;
+    }
+
+    public boolean isLandscapeMode() {
+        return getWindowManager().getDefaultDisplay().getOrientation() == 1;
+    }
+
+    public boolean isPortraitMode() {
+        return !isLandscapeMode();
+    }
+
+    public AlertDialog newYesNoDialog(int titleResourceId, int messageResourceId,
+            OnClickListener listener) {
+        return BetterActivityHelper.newYesNoDialog(this, getString(titleResourceId),
+            getString(messageResourceId), android.R.drawable.ic_dialog_info, listener);
+    }
+
+    public AlertDialog newInfoDialog(int titleResourceId, int messageResourceId) {
+        return BetterActivityHelper.newMessageDialog(this, getString(titleResourceId),
+            getString(messageResourceId), android.R.drawable.ic_dialog_info);
+    }
+
+    public AlertDialog newAlertDialog(int titleResourceId, int messageResourceId) {
+        return BetterActivityHelper.newMessageDialog(this, getString(titleResourceId),
+            getString(messageResourceId), android.R.drawable.ic_dialog_alert);
+    }
+
+    public AlertDialog newErrorHandlerDialog(int titleResourceId, Exception error) {
+        return BetterActivityHelper.newErrorHandlerDialog(this, getString(titleResourceId), error);
+    }
+
+    public AlertDialog newErrorHandlerDialog(Exception error) {
+        return newErrorHandlerDialog(getResources().getIdentifier(
+            BetterActivityHelper.ERROR_DIALOG_TITLE_RESOURCE, "string", getPackageName()), error);
+    }
+
+    public <T> Dialog newListDialog(String title, List<T> elements,
+            DialogClickListener<T> listener,
+            boolean closeOnSelect) {
+        return BetterActivityHelper.newListDialog(this, title, elements, listener, closeOnSelect);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        BetterActivityHelper.handleApplicationClosing(this, keyCode);
+        return super.onKeyDown(keyCode, event);
+    }
+}

--- a/src/main/java/com/github/droidfu/cachefu/AbstractCache.java
+++ b/src/main/java/com/github/droidfu/cachefu/AbstractCache.java
@@ -119,7 +119,12 @@ public abstract class AbstractCache<KeyT, ValT> implements Map<KeyT, ValT> {
             rootDir = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Android/data/"
                     + appContext.getPackageName() + "/cache";
         } else {
-            rootDir = appContext.getCacheDir().getAbsolutePath();
+            File internalCacheDir = appContext.getCacheDir();
+            // apparently on some configurations this can come back as null
+            if (internalCacheDir == null) {
+                return (isDiskCacheEnabled = false);
+            }
+            rootDir = internalCacheDir.getAbsolutePath();
         }
         
         setRootDir(rootDir);

--- a/src/main/java/com/github/droidfu/http/BetterHttp.java
+++ b/src/main/java/com/github/droidfu/http/BetterHttp.java
@@ -50,11 +50,12 @@ public class BetterHttp {
     public static final int DEFAULT_MAX_CONNECTIONS = 4;
     public static final int DEFAULT_SOCKET_TIMEOUT = 30 * 1000;
     public static final String DEFAULT_HTTP_USER_AGENT = "Android/DroidFu";
+    private static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
+    private static final String ENCODING_GZIP = "gzip";
 
     private static int maxConnections = DEFAULT_MAX_CONNECTIONS;
     private static int socketTimeout = DEFAULT_SOCKET_TIMEOUT;
-    private static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
-    private static final String ENCODING_GZIP = "gzip";
+    private static String httpUserAgent = DEFAULT_HTTP_USER_AGENT;
 
     private static HashMap<String, String> defaultHeaders = new HashMap<String, String>();
     private static AbstractHttpClient httpClient;
@@ -76,7 +77,7 @@ public class BetterHttp {
         HttpConnectionParams.setSoTimeout(httpParams, socketTimeout);
         HttpConnectionParams.setTcpNoDelay(httpParams, true);
         HttpProtocolParams.setVersion(httpParams, HttpVersion.HTTP_1_1);
-        HttpProtocolParams.setUserAgent(httpParams, DEFAULT_HTTP_USER_AGENT);
+        HttpProtocolParams.setUserAgent(httpParams, httpUserAgent);
 
         SchemeRegistry schemeRegistry = new SchemeRegistry();
         schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
@@ -280,6 +281,11 @@ public class BetterHttp {
     public static void setPortForScheme(String scheme, int port) {
         Scheme _scheme = new Scheme(scheme, PlainSocketFactory.getSocketFactory(), port);
         httpClient.getConnectionManager().getSchemeRegistry().register(_scheme);
+    }
+
+    public static void setUserAgent(String userAgent) {
+        BetterHttp.httpUserAgent = userAgent;
+        HttpProtocolParams.setUserAgent(httpClient.getParams(), userAgent);
     }
 
     /**

--- a/src/main/java/com/github/droidfu/http/BetterHttp.java
+++ b/src/main/java/com/github/droidfu/http/BetterHttp.java
@@ -1,9 +1,18 @@
 package com.github.droidfu.http;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
+import java.util.zip.GZIPInputStream;
 
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.HttpVersion;
 import org.apache.http.conn.params.ConnManagerParams;
 import org.apache.http.conn.params.ConnPerRouteBean;
@@ -12,6 +21,7 @@ import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.entity.HttpEntityWrapper;
 import org.apache.http.impl.client.AbstractHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
@@ -19,6 +29,7 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
+import org.apache.http.protocol.HttpContext;
 
 import android.content.Context;
 import android.content.IntentFilter;
@@ -42,6 +53,8 @@ public class BetterHttp {
 
     private static int maxConnections = DEFAULT_MAX_CONNECTIONS;
     private static int socketTimeout = DEFAULT_SOCKET_TIMEOUT;
+    private static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
+    private static final String ENCODING_GZIP = "gzip";
 
     private static HashMap<String, String> defaultHeaders = new HashMap<String, String>();
     private static AbstractHttpClient httpClient;
@@ -78,6 +91,37 @@ public class BetterHttp {
 
         ThreadSafeClientConnManager cm = new ThreadSafeClientConnManager(httpParams, schemeRegistry);
         httpClient = new DefaultHttpClient(cm, httpParams);
+
+        /*
+         * Intercept requests to have them ask for GZip encoding and intercept responses to
+         * automatically wrap the response entity for reinflation. This code is based on code from
+         * SyncService in the Google I/O 2010 {@linkplain http://code.google.com/p/iosched/
+         * scheduling app}.
+         */
+        httpClient.addRequestInterceptor(new HttpRequestInterceptor() {
+            public void process(final HttpRequest request, final HttpContext context) {
+                // Add header to accept gzip content
+                if (!request.containsHeader(HEADER_ACCEPT_ENCODING)) {
+                    request.addHeader(HEADER_ACCEPT_ENCODING, ENCODING_GZIP);
+                }
+            }
+        });
+
+        httpClient.addResponseInterceptor(new HttpResponseInterceptor() {
+            public void process(final HttpResponse response, final HttpContext context) {
+                // Inflate any responses compressed with gzip
+                final HttpEntity entity = response.getEntity();
+                final Header encoding = entity.getContentEncoding();
+                if (encoding != null) {
+                    for (HeaderElement element : encoding.getElements()) {
+                        if (element.getName().equalsIgnoreCase(ENCODING_GZIP)) {
+                            response.setEntity(new InflatingEntity(response.getEntity()));
+                            break;
+                        }
+                    }
+                }
+            }
+        });
     }
 
     /**
@@ -238,4 +282,23 @@ public class BetterHttp {
         httpClient.getConnectionManager().getSchemeRegistry().register(_scheme);
     }
 
+    /**
+     * Simple {@link HttpEntityWrapper} that inflates the wrapped
+     * {@link HttpEntity} by passing it through {@link GZIPInputStream}.
+     */
+    private static class InflatingEntity extends HttpEntityWrapper {
+        public InflatingEntity(final HttpEntity wrapped) {
+            super(wrapped);
+        }
+
+        @Override
+        public InputStream getContent() throws IOException {
+            return new GZIPInputStream(wrappedEntity.getContent());
+        }
+
+        @Override
+        public long getContentLength() {
+            return -1;
+        }
+    }
 }


### PR DESCRIPTION
Noticed there was no GZIP support in BetterHttp; I added it using the request/response-interceptor/ input-stream-wrapper style used by the Google I/O 2010 schedule app. Right now it's automatic, but if it causes problems for anyone it'd be easy enough to turn on/off with a flag, too.
