### PR TITLE
Small fix for assertEqualTimes

### DIFF
--- a/src/main/java/com/github/droidfu/http/BetterHttp.java
+++ b/src/main/java/com/github/droidfu/http/BetterHttp.java
@@ -195,14 +195,19 @@ public class BetterHttp {
     }
 
     public static BetterHttpRequest get(String url) {
-        return get(url, false);
+        return  new HttpGet(httpClient, url, defaultHeaders);
     }
 
     public static BetterHttpRequest get(String url, boolean cached) {
         if (cached && responseCache != null && responseCache.containsKey(url)) {
             return new CachedHttpRequest(url);
         }
-        return new HttpGet(httpClient, url, defaultHeaders);
+        
+        //Note: This is backwards of standard delegation to allow for testing cache
+        //hits without having to mock / expose the HttpGet class. With this
+        //configuration we can just mock get(String) and have it cover
+        //the non-cache cases
+        return get(url);
     }
 
     public static BetterHttpRequest post(String url) {

--- a/src/main/java/com/github/droidfu/http/BetterHttpRequest.java
+++ b/src/main/java/com/github/droidfu/http/BetterHttpRequest.java
@@ -72,4 +72,25 @@ public interface BetterHttpRequest {
      * Wi-Fi and 3G).
      */
     public BetterHttpResponse send() throws ConnectException;
+
+    /**
+     * Sets the value of option on this request
+     * 
+     * @param option
+     *            the http header to set
+     * @param value
+     *            the value to set the header to
+     * @return this request
+     */
+    public BetterHttpRequest addHeader(String option, String value);
+    
+
+    /**
+     * Unsets the value of option on this request
+     * 
+     * @param option
+     *            the http header to unset
+     * @return this request
+     */
+    public BetterHttpRequest removeHeader(String option);
 }

--- a/src/main/java/com/github/droidfu/http/BetterHttpRequestBase.java
+++ b/src/main/java/com/github/droidfu/http/BetterHttpRequestBase.java
@@ -154,4 +154,35 @@ public abstract class BetterHttpRequestBase implements BetterHttpRequest,
         }
         return bhttpr;
     }
+    
+    public BetterHttpRequest addHeader(String option, String value) {
+        if(request != null)
+        {
+            if(!request.containsHeader(option))
+            {
+                request.addHeader(option, value);
+            }
+            else
+            {
+                request.setHeader(option, value);
+            }
+        }
+        else
+        {
+            Log.e(BetterHttp.LOG_TAG, "Could not add header "+option+" because request was null.");
+        }
+        return this;
+    }
+    
+    public BetterHttpRequest removeHeader(String option) {
+        if(request != null && request.containsHeader(option))
+        {
+            request.removeHeaders(option);
+        }
+        else
+        {
+            Log.e(BetterHttp.LOG_TAG, "Could not add header "+option+" because request was null.");
+        }
+        return this;
+    }
 }

--- a/src/main/java/com/github/droidfu/http/CachedHttpRequest.java
+++ b/src/main/java/com/github/droidfu/http/CachedHttpRequest.java
@@ -35,4 +35,12 @@ public class CachedHttpRequest implements BetterHttpRequest {
     public BetterHttpRequest withTimeout(int timeout) {
         return this;
     }
+
+    public BetterHttpRequest addHeader(String option, String value) {
+        return this;
+    }
+
+    public BetterHttpRequest removeHeader(String option) {
+        return this;
+    }
 }

--- a/src/test/java/com/github/droidfu/http/BetterHttpRequestTest.java
+++ b/src/test/java/com/github/droidfu/http/BetterHttpRequestTest.java
@@ -1,8 +1,11 @@
 package com.github.droidfu.http;
 
+import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.http.Header;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.params.CoreConnectionPNames;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +36,65 @@ public class BetterHttpRequestTest extends BetterHttpTestBase {
         assertEquals(timeout, BetterHttp.getSocketTimeout());
         assertEquals(timeout, httpClientMock.getParams().getIntParameter(
                 CoreConnectionPNames.SO_TIMEOUT, BetterHttp.DEFAULT_SOCKET_TIMEOUT));
+    }
+    
+    @Test
+    public void testHeaderAddition()
+    {
+        BetterHttpRequest request = BetterHttp.get(url);
+        
+        HttpUriRequest uriRequest = request.unwrap();
+        
+        int headerCount = uriRequest.getAllHeaders().length;
+        
+        request.addHeader("test", "1");
+        
+        assertTrue(headerCount +1 == uriRequest.getAllHeaders().length);
+        
+        Header[] headers = uriRequest.getHeaders("test");
+        
+        assertEquals(1, headers.length);
+    }
+    
+    @Test
+    public void testHeaderReaddition()
+    {
+        BetterHttpRequest request = BetterHttp.get(url);
+        
+        HttpUriRequest uriRequest = request.unwrap();
+        
+        request.addHeader("test", "1");
+        
+        Header[] headers = uriRequest.getHeaders("test");
+        assertEquals("1", headers[0].getValue());
+        
+        request.addHeader("test", "2");
+        
+        headers = uriRequest.getHeaders("test");
+        assertEquals("2", headers[0].getValue());
+    }
+    
+    @Test
+    public void testHeaderRemoval()
+    {
+        BetterHttpRequest request = BetterHttp.get(url);
+        
+        HttpUriRequest uriRequest = request.unwrap();
+        
+        request.addHeader("test", "1");
+                
+        assertEquals(1, uriRequest.getHeaders("test").length);
+
+        request.removeHeader("test");
+
+        assertEquals(0, uriRequest.getHeaders("test").length);
+    }
+    
+    @Test
+    public void testHeaderRemoveNonExisting()
+    {
+        BetterHttpRequest request = BetterHttp.get(url);
+        request.removeHeader("UUUUUU");
     }
 
 }

--- a/src/test/java/com/github/droidfu/testsupport/TestDroidFuAssertions.java
+++ b/src/test/java/com/github/droidfu/testsupport/TestDroidFuAssertions.java
@@ -162,11 +162,14 @@ public class TestDroidFuAssertions {
     @Test
     public void assertEqualTimes() {
         Calendar cal = Calendar.getInstance();
+        cal.clear();
         cal.set(2010, Calendar.JANUARY, 1, 12, 0, 0);
 
         Date expected = cal.getTime();
-        Date actual = new Date(cal.getTime().getTime() + 50); // 50ms deviation
+        Date actual = new Date(cal.getTime().getTime() + 999); // 999ms deviation
+        DroidFuAssertions.assertTimeEquals(expected, actual);
         
+        actual = new Date(cal.getTime().getTime() + 1); // 1ms deviation
         DroidFuAssertions.assertTimeEquals(expected, actual);
     }
 }


### PR DESCRIPTION
The test case for assertEqualTimes was not clearing the value of the calendar before doing the sub-second dropping. This was causing unpredictable behavior for the test case (false negatives) when the remanant time caused the 50ms increase to roll over to a new second. I've added a call to clear to make sure the calendar is reset and also added multiple checks at 1ms and 999ms to ensure that we hit the edge cases for the test

*First github pull request so let me know if I need to fix something
